### PR TITLE
Intercept FD_ZERO for memory sanitization

### DIFF
--- a/cmepoll.c
+++ b/cmepoll.c
@@ -15,9 +15,6 @@
 #include <sys/times.h>
 #endif
 #include <sys/socket.h>
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
@@ -55,6 +52,7 @@
 #include <atl.h>
 #include "evpath.h"
 #include "cm_transport.h"
+#include "ev_select.h"
 #include <pthread.h>
 #include <sched.h>
 #define thr_thread_t pthread_t
@@ -966,8 +964,8 @@ int filedes[2];
 	struct timeval stTimeOut;	/* for select() timeout (none) */
 	int wRet;
 
-	FD_ZERO((fd_set FAR*)&(stXcptFDS));
-	FD_ZERO((fd_set FAR*)&(stWriteFDS));
+	EVPATH_FD_ZERO((fd_set FAR*)&(stXcptFDS));
+	EVPATH_FD_ZERO((fd_set FAR*)&(stWriteFDS));
 	FD_SET(sock1, (fd_set FAR*)&(stWriteFDS));
 	FD_SET(sock1, (fd_set FAR*)&(stXcptFDS));
 	stTimeOut.tv_sec  = 10;

--- a/cmfabric.c
+++ b/cmfabric.c
@@ -17,9 +17,6 @@
 #ifdef HAVE_SYS_SOCKIO_H
 #include <sys/sockio.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
@@ -68,6 +65,7 @@
 #include "evpath.h"
 #include "cm_transport.h"
 #include "cm_internal.h"
+#include "ev_select.h"
 
 #include <stdlib.h>
 
@@ -2599,7 +2597,7 @@ libcmfabric_LTX_initialize(CManager cm, CMtrans_services svc)
     svc->add_shutdown_task(cm, free_fabric_data, (void *) fabd, FREE_TASK);
     
     fabd->wake_read_fd = -1;
-    FD_ZERO(&fabd->readset);
+    EVPATH_FD_ZERO(&fabd->readset);
     fabd->nfds = 0;
     return (void *) fabd;
 }

--- a/cmselect.c
+++ b/cmselect.c
@@ -15,9 +15,6 @@
 #include <sys/times.h>
 #endif
 #include <sys/socket.h>
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
@@ -55,6 +52,7 @@
 #include <atl.h>
 #include "evpath.h"
 #include "cm_transport.h"
+#include "ev_select.h"
 #include <pthread.h>
 #include <sched.h>
 #define thr_thread_t pthread_t
@@ -121,9 +119,9 @@ CManager cm;
     select_data_ptr sd = malloc(sizeof(struct select_data));
     *sdp = sd;
     sd->fdset = svc->malloc_func(sizeof(fd_set));
-    FD_ZERO((fd_set *) sd->fdset);
+    EVPATH_FD_ZERO((fd_set *) sd->fdset);
     sd->write_set = svc->malloc_func(sizeof(fd_set));
-    FD_ZERO((fd_set *) sd->write_set);
+    EVPATH_FD_ZERO((fd_set *) sd->write_set);
     sd->server_thread =  (thr_thread_t) NULL;
     sd->closed = 0;
     sd->sel_item_max = 0;
@@ -334,7 +332,7 @@ int timeout_usec;
 		    fd_set test_set;
 		    timeout.tv_usec = 0;
 		    timeout.tv_sec = 0;
-		    FD_ZERO(&test_set);
+		    EVPATH_FD_ZERO(&test_set);
 		    FD_SET(j, &test_set);
 		    errno = 0;
 		    select(sd->sel_item_max+1, &test_set, (fd_set *) NULL,
@@ -966,8 +964,8 @@ int filedes[2];
 	struct timeval stTimeOut;	/* for select() timeout (none) */
 	int wRet;
 
-	FD_ZERO((fd_set FAR*)&(stXcptFDS));
-	FD_ZERO((fd_set FAR*)&(stWriteFDS));
+	EVPATH_FD_ZERO((fd_set FAR*)&(stXcptFDS));
+	EVPATH_FD_ZERO((fd_set FAR*)&(stWriteFDS));
 	FD_SET(sock1, (fd_set FAR*)&(stWriteFDS));
 	FD_SET(sock1, (fd_set FAR*)&(stXcptFDS));
 	stTimeOut.tv_sec  = 10;

--- a/ev_select.h
+++ b/ev_select.h
@@ -1,0 +1,22 @@
+#ifndef EVPATH_SELECT_H
+#define EVPATH_SELECT_H
+
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+
+#if defined(__has_feature) && __has_feature(memory_sanitizer)
+
+#include <string.h>
+#define EVPATH_FD_ZERO(set) \
+do { \
+    memset((set), 0, sizeof(fd_set)); \
+} while (0)
+
+#else
+
+#define EVPATH_FD_ZERO FD_ZERO
+
+#endif
+
+#endif

--- a/zpl-enet/include/enet.h
+++ b/zpl-enet/include/enet.h
@@ -164,6 +164,8 @@
     #include <Availability.h>
     #endif
 
+    #include "ev_select.h"
+
     #ifndef MSG_NOSIGNAL
     #define MSG_NOSIGNAL 0
     #endif
@@ -192,7 +194,7 @@
 
     typedef fd_set ENetSocketSet;
 
-    #define ENET_SOCKETSET_EMPTY(sockset)          FD_ZERO(&(sockset))
+    #define ENET_SOCKETSET_EMPTY(sockset)          EVPATH_FD_ZERO(&(sockset))
     #define ENET_SOCKETSET_ADD(sockset, socket)    FD_SET(socket, &(sockset))
     #define ENET_SOCKETSET_REMOVE(sockset, socket) FD_CLR(socket, &(sockset))
     #define ENET_SOCKETSET_CHECK(sockset, socket)  FD_ISSET(socket, &(sockset))


### PR DESCRIPTION
Some standard library implementations implement FD_ZERO in assembly
language, which confuses some memory sanitizaton tools. Intercept
calls to FD_ZERO with a pure C implementation if memory sanitization
is used.