### PR TITLE
Fix has_feature check for older compilers

### DIFF
--- a/ev_select.h
+++ b/ev_select.h
@@ -5,7 +5,8 @@
 #include <sys/select.h>
 #endif
 
-#if defined(__has_feature) && __has_feature(memory_sanitizer)
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
 
 #include <string.h>
 #define EVPATH_FD_ZERO(set) \
@@ -13,10 +14,11 @@ do { \
     memset((set), 0, sizeof(fd_set)); \
 } while (0)
 
-#else
+#endif
+#endif
 
+#ifndef EVPATH_FD_ZERO
 #define EVPATH_FD_ZERO FD_ZERO
-
 #endif
 
 #endif


### PR DESCRIPTION
@KyleFromKitware The prior form of the check for address sanitizer was broken for older compilers...