### PR TITLE
EVPath: resolve libm test false positives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,9 @@ set(_pkg_config_libs)
 set(_pkg_config_private_libs)
 
 include(CheckCSourceCompiles)
+
+# Avoid recent compilers to optimizing out libm function calls
+set(CMAKE_REQUIRED_FLAGS "-O0")
 set(LIBM_TEST_SOURCE "#include<math.h>\nfloat f; int main(){sqrt(f);return 0;}")
 check_c_source_compiles("${LIBM_TEST_SOURCE}" HAVE_MATH)
 if(NOT HAVE_MATH)


### PR DESCRIPTION
Recent compilers by default optimize out the Math.h function calls in
the C test provided at the CMakeLists.txt used to check if Math.h
functions are already included in libc, thus resulting in false
positives.

This removes most optimizations for the C test for libm at the CMakeLists.txt

This results in linking errors in some machines.

Backport from a patch for ADIOS2 OpenSUSE pkg.

https://build.opensuse.org/package/view_file/home:vicentebolea/ADIOS2/evpath-link-m.patch?expand=1

Attached are the error messages that we are attempting to resolve with this PR

[failing-osc-evpath.log](https://github.com/GTkorvo/evpath/files/7146007/failing-osc-evpath.log)
